### PR TITLE
Appdata related patches

### DIFF
--- a/data/com.github.alexkdeveloper.desktop-files-creator.appdata.xml.in
+++ b/data/com.github.alexkdeveloper.desktop-files-creator.appdata.xml.in
@@ -14,7 +14,7 @@
     <binary>com.github.alexkdeveloper.desktop-files-creator</binary>
   </provides>
 
-  <developer_name translatable="no">Alex Kryuchkov</developer_name>
+  <developer_name translate="no">Alex Kryuchkov</developer_name>
 
   <url type="homepage">https://github.com/alexkdeveloper/desktop-files-creator</url>
   <url type="bugtracker">https://github.com/alexkdeveloper/desktop-files-creator/issues</url>
@@ -45,77 +45,77 @@
 
   <releases>
     <release version="1.2.7" date="2024-03-29">
-      <description translatable="no">
+      <description translate="no">
         <ul>
 	  <li>Updated translations</li>
         </ul>
       </description>
     </release>
     <release version="1.2.6" date="2024-03-23">
-      <description translatable="no">
+      <description translate="no">
         <ul>
 	  <li>Updated to GNOME Platform version 46</li>
         </ul>
       </description>
     </release>
     <release version="1.2.5" date="2023-09-26">
-      <description translatable="no">
+      <description translate="no">
         <ul>
 	  <li>Updated Czech translation</li>
         </ul>
       </description>
     </release>
     <release version="1.2.4" date="2023-09-23">
-      <description translatable="no">
+      <description translate="no">
         <ul>
 	  <li>Updated to GNOME Platform version 45</li>
         </ul>
       </description>
     </release>
     <release version="1.2.3" date="2023-08-18">
-      <description translatable="no">
+      <description translate="no">
         <ul>
 	  <li>Port to FileDialog</li>
         </ul>
       </description>
     </release>
     <release version="1.2.2" date="2023-03-22">
-      <description translatable="no">
+      <description translate="no">
         <ul>
 	  <li>Updated to GNOME Platform version 44</li>
         </ul>
       </description>
     </release>
     <release version="1.2.1" date="2023-03-07">
-      <description translatable="no">
+      <description translate="no">
         <ul>
 	  <li>Fixed UI</li>
         </ul>
       </description>
     </release>
     <release version="1.2.0" date="2022-11-10">
-      <description translatable="no">
+      <description translate="no">
         <ul>
 	  <li>Added additional icon types for the selection window</li>
         </ul>
       </description>
     </release>
     <release version="1.1.9" date="2022-11-07">
-      <description translatable="no">
+      <description translate="no">
         <ul>
 	  <li>Port to FileChooserNative</li>
         </ul>
       </description>
     </release>
     <release version="1.1.8" date="2022-09-24">
-      <description translatable="no">
+      <description translate="no">
         <ul>
 	  <li>Update to GNOME Platform version 43</li>
         </ul>
       </description>
     </release>
     <release version="1.1.7" date="2022-09-07">
-      <description translatable="no">
+      <description translate="no">
         <ul>
 	  <li>Added the ability to select svg files for the application icon</li>
 	  <li>Update Italian translation</li>
@@ -123,7 +123,7 @@
       </description>
     </release>
     <release version="1.1.6" date="2022-09-03">
-      <description translatable="no">
+      <description translate="no">
         <ul>
 	  <li>Update Spanish translation</li>
           <li>Added clear buttons to exec and icon rows</li>
@@ -131,7 +131,7 @@
       </description>
     </release>
     <release version="1.1.5" date="2022-08-22">
-      <description translatable="no">
+      <description translate="no">
         <ul>
 	  <li>Update Russian translation</li>
           <li>Added Turkish translation</li>
@@ -139,42 +139,42 @@
       </description>
     </release>
     <release version="1.1.4" date="2022-08-20">
-      <description translatable="no">
+      <description translate="no">
         <ul>
 	  <li>Update Italian translation</li>
         </ul>
       </description>
     </release>
     <release version="1.1.3" date="2022-08-12">
-      <description translatable="no">
+      <description translate="no">
         <ul>
 	  <li>Port to AdwMessageDialog</li>
         </ul>
       </description>
     </release>
     <release version="1.1.2" date="2022-08-09">
-      <description translatable="no">
+      <description translate="no">
         <ul>
 	  <li>Port to AdwEntryRow</li>
         </ul>
       </description>
     </release>
     <release version="1.1.1" date="2022-07-03">
-      <description translatable="no">
+      <description translate="no">
         <ul>
 	  <li>Pop-up messages were introduced</li>
         </ul>
       </description>
     </release>
     <release version="1.1.0" date="2022-05-16">
-      <description translatable="no">
+      <description translate="no">
         <ul>
 	  <li>Update English translation</li>
         </ul>
       </description>
     </release>
      <release version="1.0.9" date="2022-04-30">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added Dutch translation</li>
 	  <li>Update Czech translation</li>
@@ -182,14 +182,14 @@
       </description>
     </release>
      <release version="1.0.8" date="2022-04-08">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added Swedish translation</li>
         </ul>
       </description>
     </release>
     <release version="1.0.7" date="2022-03-17">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added Russian translation</li>
           <li>Update Italian translation</li>
@@ -198,21 +198,21 @@
       </description>
     </release>
     <release version="1.0.6" date="2022-03-10">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Port to GTK4 + libadwaita</li>
         </ul>
       </description>
     </release>
     <release version="1.0.5" date="2022-02-16">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>A small update to the user interface</li>
         </ul>
       </description>
     </release>
     <release version="1.0.4" date="2022-02-14">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Updated user interface</li>
           <li>Added Slovak translation</li>
@@ -220,7 +220,7 @@
       </description>
     </release>
     <release version="1.0.3" date="2022-02-02">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Port to libhandy</li>
           <li>Added Spanish translation</li>
@@ -228,14 +228,14 @@
       </description>
     </release>
     <release version="1.0.2" date="2021-12-29">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added Italian translation</li>
         </ul>
       </description>
     </release>
     <release version="1.0.1" date="2021-12-20">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Update to GNOME Platform version 41</li>
           <li>Added Czech translation</li>
@@ -243,7 +243,7 @@
       </description>
     </release>
     <release version="1.0.0" date="2021-09-19">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Initial release</li>
         </ul>

--- a/data/com.github.alexkdeveloper.desktop-files-creator.appdata.xml.in
+++ b/data/com.github.alexkdeveloper.desktop-files-creator.appdata.xml.in
@@ -15,6 +15,9 @@
   </provides>
 
   <developer_name translate="no">Alex Kryuchkov</developer_name>
+  <developer id="io.github.alexkdeveloper">
+    <name translate="no">Alex Kryuchkov</name>
+  </developer>
 
   <url type="homepage">https://github.com/alexkdeveloper/desktop-files-creator</url>
   <url type="bugtracker">https://github.com/alexkdeveloper/desktop-files-creator/issues</url>


### PR DESCRIPTION
### appdata: translate=no properties

It appears that the appstream project no longer supports
`translatable=no` properties, and gettext extract them as translatable.

I opened an issue to inform about the situation, but `translatable=no`
properties are not accepted by developers. You can find the issue
here: `https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html

### appdata: Add developer ID

Flathub requires a developer tag and developer ID. Also Appstream decided to use rdns structure for developer ID.

It allows reverse-dns IDs like sh.cozy, de.geigi or Fediverse handle (like @user@example.org)

> A developer tag with a name child tag must be present.
> Only one developer tag is allowed and the name tag also must be present only once in untranslated form.

```
<developer id="tld.vendor">
  <name>Developer name</name>
</developer>
```
Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

Source: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer